### PR TITLE
Updating the setpoints wasn't working as expected

### DIFF
--- a/quickApp/Nest/thermostat.lua
+++ b/quickApp/Nest/thermostat.lua
@@ -16,6 +16,7 @@ function NestThermostat:__init(device)
     -- setup default values
     self:updateProperty("thermostatMode", "Off")
     self:updateProperty("heatingThermostatSetpoint", 8)
+    self:updateProperty("coolingThermostatSetpoint", 30)
     self:updateProperty("log", "")
 end
 
@@ -211,8 +212,9 @@ function NestThermostat:setHeatingThermostatSetpoint(value)
       )
     elseif (self.properties.thermostatMode == "Auto")
     then
+      self:debug('Original coolingThermostatSetpoint' .. self.properties.coolingThermostatSetpoint)
       self:callNestApi("sdm.devices.commands.ThermostatTemperatureSetpoint.SetRange",
-          {['heatCelsius'] = roundedValue, ['coolCelsius'] = self:getDegreesCelsius(self.properties.coolingThermostatSetpoint)},
+          {['heatCelsius'] = roundedValue, ['coolCelsius'] = self.properties.coolingThermostatSetpoint},
           function()
               self:updateProperty("heatingThermostatSetpoint", roundedValue)
           end
@@ -236,8 +238,9 @@ function NestThermostat:setCoolingThermostatSetpoint(value)
       )
     elseif (self.properties.thermostatMode == "Auto")
     then
+      self:debug('Original heatingThermostatSetpoint' .. self.properties.heatingThermostatSetpoint)
       self:callNestApi("sdm.devices.commands.ThermostatTemperatureSetpoint.SetRange",
-          {['heatCelsius'] = self:getDegreesCelsius(self.properties.heatingThermostatSetpoint), ['coolCelsius'] = roundedValue},
+          {['heatCelsius'] = self.properties.heatingThermostatSetpoint, ['coolCelsius'] = roundedValue},
           function()
               self:updateProperty("coolingThermostatSetpoint", roundedValue)
           end


### PR DESCRIPTION
I installed your update and played around with it. The first glaring problem was that the setpoint for the unchanged setpoint does not need to be converted to °C. The value you are using is already in Celsius. I simply removed the call to getDegreesCelsius for that setpoint.

This next problem is very subtle. I tried to track down a way to fix it but can't quite do that yet. The problem is that when I change both setpoints in the device screen, only the last change is sent to the thermostat. What I mean by that is that since the heating setpoint is updated first, the value doesn't get updated in the traits area or properties area. Then the cooling setpoint is changed but the old heating setpoint is still in the body['traits']['sdm.devices.traits.ThermostatTemperatureSetpoint'] (perhaps because while the value may have been sent to the thermostat, the thermostat has not been read back into the body yet?). My thoughts were to have an setAutoThermostatSetpoint() method and use it when the device is in Auto mode. But, for the life of me, I can't see where those methods are connected to the event system. That may not make sense within the context of the Fibaro system but IMHO the documentation is very sparse and your ability to have hunted down the mechanisms for all of this is astounding. (Maybe when I grow up I can be just like you [weird American humor]).

And finally, this won't be a problem for me but a final check should prevent the cooling setpoint to be less than the heating setpoint. I notice in the Nest app when I bump one value up or down towards the other value it automatically adjusts the value to keep them 2° or 3° different. Not at all sure of a clean way to do that other than to pick one and adjust it when that condition is met.

If I can help further with my setup just let me know. I'm happy to oblige.

Peter